### PR TITLE
Change href of home button to ./

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
     <nav>
         <img src="Assets/Classic Logo.png" alt="Classic Logo" id="logo">
         <ul>
-            <li class="separator"><a href="index.html">Home</a></li>
+            <li class="separator"><a href="./">Home</a></li>
             <li><a href="https://discord.com/invite/Hr7tC837ZW"><img src="SVGs/discord.svg" alt="Discord"></a></li>
             <li><a href="https://github.com/strxproject"><img src="SVGs/github.svg" alt="GitHub"></a></li>
             <li><a href="https://ko-fi.com/starixproject"><img src="SVGs/kofi.svg" alt="Ko-fi"></a></li>


### PR DESCRIPTION
When navigating to classic7.lol, the URL is simply https://classic7.lol/
If you click the home button while on the home page, you are navigated to https://classic7.lol/index.html
This is still the same page, but it's not as clean as it could be
Changing the href of the home button from index.html to ./ will make it stay on https://classic7.lol and not append the file name to the URL.